### PR TITLE
Add attributes sorting option

### DIFF
--- a/lib/rails-model-schema.coffee
+++ b/lib/rails-model-schema.coffee
@@ -10,6 +10,10 @@ module.exports = RailsModelSchema =
       type: "boolean"
       default: true
       description: "Show the schema panel when opening a file."
+    sortByAlphabeticalOrder:
+      type: "boolean"
+      default: false
+      description: "Sort the attributes by alphabetical order."
 
   serialize: -> {}
 

--- a/lib/schema-content.coffee
+++ b/lib/schema-content.coffee
@@ -1,4 +1,5 @@
 {pluralize, underscore} = require('inflection')
+_ = require 'underscore-plus'
 
 tableName = (modelClassName)->
   underscore(pluralize(modelClassName))
@@ -48,6 +49,12 @@ class SchemaContent
       columnRegexp: /\bt\.([a-zA-Z_]+)[\W]+"([a-zA-Z_]+)"[^\n]*/
       endRegexp: /^[\s]+end$/
     }
+
+  getAttributes: ->
+    if atom.config.get('rails-model-schema.sortByAlphabeticalOrder')
+      _.sortBy @attributes, (attr) -> attr.name
+    else
+      @attributes
 
   push: ({type, name, line})->
     @attributes.push(type: type, name: name, line: line)

--- a/lib/schema-view.coffee
+++ b/lib/schema-view.coffee
@@ -26,7 +26,7 @@ class SchemaView extends View
             @th "Type"
             @th ""
         @tbody =>
-          for {name, type, line} in schemaContent.attributes
+          for {name, type, line} in schemaContent.getAttributes()
             @tr class: "attribute-row", =>
               @td =>
                 @span class: "attribute-name", name

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "atom-space-pen-views": "~> 2.1",
     "event-kit": "^1.2.0",
     "inflection": "^1.7.1",
-    "pathwatcher": "~>6.3"
+    "pathwatcher": "~>6.3",
+    "underscore-plus": "^1.6.0"
   }
 }


### PR DESCRIPTION
Hi everyone!

I added an option to sort attributes by name in the table. Unfortunately, I was unable to display package's settings in the settings view. I'll be glad to get advice on this part.

I added the 'underscore-plus' dependency to the plugin to ease attributes sorting but I could understand if that is a problem for you.

It's the first I contribute to the development of an atom plugin and the first time I develop an atom plugin. I'm open to every comment or advice on this pull request.

Lukkor