### PR TITLE
Recognition of self.table_name declaration

### DIFF
--- a/lib/ruby-editor.coffee
+++ b/lib/ruby-editor.coffee
@@ -3,6 +3,7 @@ fs = require "fs"
 
 SCHEMA_FILE = "db/schema.rb"
 CLASS_REGEX = /class ([a-zA-Z0-9:]+)([\s]+<[\s]+([a-zA-Z0-9:]+))?/
+DECLARED_TABLE_REGEXP = /self\.table_name[\s]+=[\s]["']+([a-zA-Z0-9:]+)["']?/
 
 findFile = (directory, file) ->
   location = path.join(directory, file)
@@ -19,6 +20,9 @@ class RubyEditor
 
   ruby: ->
     @file && @file.path && (path.extname(@file.path) == ".rb")
+
+  declaredTableName: ->
+    @_declaredTableName ?= @_getDeclaredTableName()
 
   mainClass: ->
     @_mainClass ?= @_getMainClass()
@@ -44,5 +48,10 @@ class RubyEditor
   _getClassMatch: ->
     content = @editor.getBuffer().cachedText ? ""
     content.match(CLASS_REGEX)
+
+  _getDeclaredTableName: ->
+    content = @editor.getBuffer().cachedText ? ""
+    declaredTableMatch = content.match(DECLARED_TABLE_REGEXP)
+    declaredTableMatch && declaredTableMatch[1]
 
 module.exports = RubyEditor

--- a/lib/schema-content.coffee
+++ b/lib/schema-content.coffee
@@ -1,7 +1,7 @@
 {pluralize, underscore} = require('inflection')
 _ = require 'underscore-plus'
 
-tableName = (modelClassName)->
+classToTableName = (modelClassName)->
   underscore(pluralize(modelClassName))
 
 normalizeSuperClass = (modelClassName) ->
@@ -11,14 +11,14 @@ normalizeSuperClass = (modelClassName) ->
     modelClassName
 
 class SchemaContent
-  constructor: (@modelClass, @modelSuperClass) ->
+  constructor: (@modelClass, @modelSuperClass, @tableName) ->
     @attributes = []
     @schemaFound = false
     @tableFound = false
     @tableScanned = false
-    @tableName = tableName(@modelClass)
+    @tableName ?= classToTableName(@modelClass)
     @modelSuperClass = normalizeSuperClass(@modelSuperClass)
-    @superTableName = tableName(@modelSuperClass) if @modelSuperClass
+    @superTableName = classToTableName(@modelSuperClass) if @modelSuperClass
 
   fill: (schemaContent) ->
     lines = schemaContent.toString().split(/\n/)

--- a/lib/schema-service.coffee
+++ b/lib/schema-service.coffee
@@ -15,7 +15,11 @@ class SchemaService
   schemaContent: ->
     schemaFile = @schemaFile()
     if schemaFile?
-      schemaContent = new SchemaContent(@modelEditor.mainClass(), @modelEditor.superClass())
+      schemaContent = new SchemaContent(
+        @modelEditor.mainClass(),
+        @modelEditor.superClass(),
+        @modelEditor.declaredTableName()
+      )
       schemaContent.fill(fs.readFileSync(schemaFile))
       schemaContent
 

--- a/spec/files/student.rb
+++ b/spec/files/student.rb
@@ -1,0 +1,3 @@
+class Student
+  self.table_name = "users"
+end


### PR DESCRIPTION
Fixes https://github.com/juliogarciag/atom-rails-model-schema/issues/27

It allows to discover the table name of a ruby file by looking at the `self.table_name = "table"` declaration.